### PR TITLE
Fix scrolling disabled attributes

### DIFF
--- a/src/com/github/czyzby/lml/parser/impl/attribute/scroll/ScrollDisabledXLmlAttribute.java
+++ b/src/com/github/czyzby/lml/parser/impl/attribute/scroll/ScrollDisabledXLmlAttribute.java
@@ -6,7 +6,7 @@ import com.github.czyzby.lml.parser.tag.LmlAttribute;
 import com.github.czyzby.lml.parser.tag.LmlTag;
 
 /** See {@link ScrollPane#setScrollingDisabled(boolean, boolean)}. Sets X scrolling to the parsed value and Y to default
- * value: true, because there were no getters or individual setters available. If you want to disable both, use
+ * value: false, because there were no getters or individual setters available. If you want to disable both, use
  * {@link ScrollDisabledLmlAttribute} instead. Mapped to "disableX", "disabledX".
  *
  * @author MJ */
@@ -19,6 +19,6 @@ public class ScrollDisabledXLmlAttribute implements LmlAttribute<ScrollPane> {
     @Override
     public void process(final LmlParser parser, final LmlTag tag, final ScrollPane actor,
             final String rawAttributeData) {
-        actor.setScrollingDisabled(parser.parseBoolean(rawAttributeData, actor), true);
+        actor.setScrollingDisabled(parser.parseBoolean(rawAttributeData, actor), false);
     }
 }

--- a/src/com/github/czyzby/lml/parser/impl/attribute/scroll/ScrollDisabledYLmlAttribute.java
+++ b/src/com/github/czyzby/lml/parser/impl/attribute/scroll/ScrollDisabledYLmlAttribute.java
@@ -6,7 +6,7 @@ import com.github.czyzby.lml.parser.tag.LmlAttribute;
 import com.github.czyzby.lml.parser.tag.LmlTag;
 
 /** See {@link ScrollPane#setScrollingDisabled(boolean, boolean)}. Sets Y scrolling to the parsed value and X to default
- * value: true, because there were no getters or individual setters available. If you want to disable both, use
+ * value: false, because there were no getters or individual setters available. If you want to disable both, use
  * {@link ScrollDisabledLmlAttribute} instead. Mapped to "disableY", "disabledY".
  *
  * @author MJ */
@@ -19,6 +19,6 @@ public class ScrollDisabledYLmlAttribute implements LmlAttribute<ScrollPane> {
     @Override
     public void process(final LmlParser parser, final LmlTag tag, final ScrollPane actor,
             final String rawAttributeData) {
-        actor.setScrollingDisabled(true, parser.parseBoolean(rawAttributeData, actor));
+        actor.setScrollingDisabled(false, parser.parseBoolean(rawAttributeData, actor));
     }
 }


### PR DESCRIPTION
It doesn't make sense to set other value to true because that would always disable both directions if using `disabledX` or `disabledY`