### PR TITLE
Fixed DebugRecursively attribute.

### DIFF
--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/group/DebugRecursivelyLmlAttribute.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/attribute/group/DebugRecursivelyLmlAttribute.java
@@ -2,14 +2,30 @@ package com.github.czyzby.lml.parser.impl.attribute.group;
 
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.github.czyzby.lml.parser.LmlParser;
+import com.github.czyzby.lml.parser.action.ActorConsumer;
 import com.github.czyzby.lml.parser.tag.LmlAttribute;
 import com.github.czyzby.lml.parser.tag.LmlTag;
+import com.github.czyzby.lml.util.LmlUtilities;
 
 /** See {@link Group#setDebug(boolean, boolean)}. Second method argument is always true, so this method sets debug for
  * all children; for non-recursive debug, use default debug attribute. Mapped to "debugRecursively".
  *
  * @author MJ */
 public class DebugRecursivelyLmlAttribute implements LmlAttribute<Group> {
+    private static class DebugAction implements ActorConsumer<Object, Object> {
+        private boolean value;
+
+        private DebugAction(boolean value) {
+            this.value = value;
+        }
+
+        @Override
+        public Object consume(Object actor) {
+            ((Group) actor).setDebug(value, true);
+            return null;
+        }
+    }
+
     @Override
     public Class<Group> getHandledType() {
         return Group.class;
@@ -17,6 +33,6 @@ public class DebugRecursivelyLmlAttribute implements LmlAttribute<Group> {
 
     @Override
     public void process(final LmlParser parser, final LmlTag tag, final Group actor, final String rawAttributeData) {
-        actor.setDebug(parser.parseBoolean(rawAttributeData, actor), true);
+        LmlUtilities.getLmlUserObject(actor).addOnCloseAction(new DebugAction(parser.parseBoolean(rawAttributeData)));
     }
 }


### PR DESCRIPTION
DebugRecursively attribute needs to be processed after all children are added.