### PR TITLE
Make LocaleService handle locale changes correct before any view controller is created.

### DIFF
--- a/mvc/src/main/java/com/github/czyzby/autumn/mvc/component/i18n/LocaleService.java
+++ b/mvc/src/main/java/com/github/czyzby/autumn/mvc/component/i18n/LocaleService.java
@@ -221,7 +221,10 @@ public class LocaleService extends AbstractAnnotationProcessor<I18nLocale> {
                     && Strings.isNotEmpty(localeService.localePreferencesPath)) {
                 localeService.saveLocaleInPreferences();
             }
-            localeService.interfaceService.reload();
+            InterfaceService interfaceService = localeService.interfaceService;
+            if (interfaceService.getCurrentController() != null) {
+                interfaceService.reload();
+            }
         }
     }
 }


### PR DESCRIPTION
I've added an extra `InterfaceServices` check for any active controller in `LocaleService`'s on locale change default action. This way it's now possible to switch locale even before first view controller is created.