### PR TITLE
GWT modules for autumn test projects updated

### DIFF
--- a/examples/gdx-autumn-mvc-simple/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/build.gradle
@@ -62,10 +62,13 @@ project(":html") {
         compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
         compile "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
         compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
+        compile "com.github.czyzby:gdx-autumn:$libVersion:sources"
         compile "com.github.czyzby:gdx-autumn-gwt:$libVersion"
         compile "com.github.czyzby:gdx-autumn-gwt:$libVersion:sources"
         compile "com.github.czyzby:gdx-autumn-mvc:$libVersion:sources"
+        compile "com.github.czyzby:gdx-kiwi:$libVersion:sources"
         compile "com.github.czyzby:gdx-lml-vis:$libVersion:sources"
+        compile "com.github.czyzby:gdx-lml:$libVersion:sources"
         compile "com.kotcrab.vis:vis-ui:$visVersion:sources"
     }
 }

--- a/examples/gdx-autumn-mvc-simple/html/build.gradle
+++ b/examples/gdx-autumn-mvc-simple/html/build.gradle
@@ -1,10 +1,11 @@
-apply plugin: "java"
-apply plugin: "jetty"
+apply plugin: 'gwt'
+apply plugin: 'war'
+apply plugin: 'jetty'
 
 gwt {
-    gwtVersion='2.6.0' // Should match the gwt version used for building the gwt backend
-    maxHeapSize="1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
-    minHeapSize="1G"
+    gwtVersion = gwtFrameworkVersion // Should match the version used for building the GWT backend. See gradle.properties.
+    maxHeapSize = "1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
+    minHeapSize = "1G"
 
     src = files(file("src/")) // Needs to be in front of "modules" below.
     modules 'com.github.czyzby.GdxDefinition'
@@ -13,7 +14,6 @@ gwt {
 
     compiler {
         strict = true;
-        enableClosureCompiler = true;
         disableCastChecking = true;
     }
 }

--- a/examples/gdx-autumn-mvc-simple/html/src/com/github/czyzby/GdxDefinition.gwt.xml
+++ b/examples/gdx-autumn-mvc-simple/html/src/com/github/czyzby/GdxDefinition.gwt.xml
@@ -14,4 +14,5 @@
 	<entry-point class='com.github.czyzby.client.HtmlLauncher' />
 	
 	<set-configuration-property name="gdx.assetpath" value="../android/assets" />
+	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 </module>

--- a/examples/gdx-autumn-tests/html/build.gradle
+++ b/examples/gdx-autumn-tests/html/build.gradle
@@ -1,10 +1,11 @@
-apply plugin: "java"
-apply plugin: "jetty"
+apply plugin: 'gwt'
+apply plugin: 'war'
+apply plugin: 'jetty'
 
 gwt {
-    gwtVersion='2.6.0' // Should match the gwt version used for building the gwt backend
-    maxHeapSize="1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
-    minHeapSize="1G"
+    gwtVersion = gwtFrameworkVersion // Should match the version used for building the GWT backend. See gradle.properties.
+    maxHeapSize = "1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
+    minHeapSize = "1G"
 
     src = files(file("src/")) // Needs to be in front of "modules" below.
     modules 'com.github.czyzby.GdxDefinition'
@@ -13,7 +14,6 @@ gwt {
 
     compiler {
         strict = true;
-        enableClosureCompiler = true;
         disableCastChecking = true;
     }
 }

--- a/examples/gdx-autumn-tests/html/src/com/github/czyzby/GdxDefinition.gwt.xml
+++ b/examples/gdx-autumn-tests/html/src/com/github/czyzby/GdxDefinition.gwt.xml
@@ -9,4 +9,5 @@
 	<entry-point class='com.github.czyzby.client.HtmlLauncher' />
 	
 	<set-configuration-property name="gdx.assetpath" value="../core/assets" />
+	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 </module>


### PR DESCRIPTION
Appears that `gdx-autumn-mvc-simple` and `gdx-autumn-tests` have outdated Gradle configuration and their module structure a little different from other test projects. Probably these both require structure refactoring, but for now I just updated GWT modules, so at least they be compilable.