### PR TITLE
LibGDX 1.9.11 compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
   ext {
     projectVersion = '1.9'
-    gdxVersion = '1.9.10'
+    gdxVersion = '1.9.11'
     isSnapshot = '-SNAPSHOT'
     libVersion = "$projectVersion.$gdxVersion$isSnapshot"
   }

--- a/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/GdxMaps.java
+++ b/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/GdxMaps.java
@@ -96,7 +96,9 @@ public class GdxMaps extends UtilitiesClass {
      * @param <Value> type of map values. */
     public static <Key, Value> IdentityMap<Key, Value> newIdentityMap(
             final IdentityMap<? extends Key, ? extends Value> map) {
-        return new IdentityMap<Key, Value>(map);
+        IdentityMap<Key, Value> result = new IdentityMap<Key, Value>(map.size);
+        result.putAll(map);
+        return result;
     }
 
     /** @param keyAndValues pairs of keys and values. Each value has to be proceeded by a key.

--- a/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/immutable/ImmutableArray.java
+++ b/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/immutable/ImmutableArray.java
@@ -1,11 +1,9 @@
 package com.github.czyzby.kiwi.util.gdx.collection.immutable;
 
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.Collections;
+
+import java.util.Comparator;
 
 /** An ordered or unordered array of objects. Semi-immutable. Extends LibGDX Array class, deprecating and throwing
  * UnsupportedOperationExceptions on all operations that mutate the array. It is not truly immutable, because the
@@ -22,7 +20,7 @@ public class ImmutableArray<Type> extends Array<Type> {
     private final boolean ordered;
     @SuppressWarnings("unused") private final Type[] items;
 
-    private ImmutableArrayIterable<Type> arrayIterable;
+    private ArrayIterable<Type> iterable;
 
     /** Creates a new ordered, immutable array containing the elements in the specified array. The new array will have
      * the same type of backing array.
@@ -107,6 +105,21 @@ public class ImmutableArray<Type> extends Array<Type> {
     @Override
     @Deprecated
     public void add(final Type value) {
+        throw new UnsupportedOperationException("Cannot modify ImmutableArray.");
+    }
+
+    @Override
+    public void add(Type value1, Type value2) {
+        throw new UnsupportedOperationException("Cannot modify ImmutableArray.");
+    }
+
+    @Override
+    public void add(Type value1, Type value2, Type value3) {
+        throw new UnsupportedOperationException("Cannot modify ImmutableArray.");
+    }
+
+    @Override
+    public void add(Type value1, Type value2, Type value3, Type value4) {
         throw new UnsupportedOperationException("Cannot modify ImmutableArray.");
     }
 
@@ -255,82 +268,9 @@ public class ImmutableArray<Type> extends Array<Type> {
     }
 
     @Override
-    public Iterator<Type> iterator() {
-        if (arrayIterable == null) {
-            arrayIterable = new ImmutableArrayIterable<Type>(this);
-        }
-        return arrayIterable.iterator();
-    }
-
-    // Based on Array.ArrayIterator.
-    public static class ImmutableArrayIterator<Type> implements Iterator<Type>, Iterable<Type> {
-        private final Array<Type> array;
-        private int index;
-        private boolean valid = true;
-
-        public ImmutableArrayIterator(final Array<Type> array) {
-            this.array = array;
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (!valid) {
-                throw new GdxRuntimeException("#iterator() cannot be used nested.");
-            }
-            return index < array.size;
-        }
-
-        @Override
-        public Type next() {
-            if (index >= array.size) {
-                throw new NoSuchElementException(String.valueOf(index));
-            }
-            if (!valid) {
-                throw new GdxRuntimeException("#iterator() cannot be used nested.");
-            }
-            return array.items[index++];
-        }
-
-        public void reset() {
-            index = 0;
-        }
-
-        @Override
-        public Iterator<Type> iterator() {
-            return this;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("Array is immutable.");
-        }
-    }
-
-    // Based on Array.ArrayIterable.
-    public static class ImmutableArrayIterable<Type> implements Iterable<Type> {
-        private final Array<Type> array;
-        private ImmutableArrayIterator<Type> iterator1, iterator2;
-
-        public ImmutableArrayIterable(final Array<Type> array) {
-            this.array = array;
-        }
-
-        @Override
-        public Iterator<Type> iterator() {
-            if (iterator1 == null) {
-                iterator1 = new ImmutableArrayIterator<Type>(array);
-                iterator2 = new ImmutableArrayIterator<Type>(array);
-            }
-            if (!iterator1.valid) {
-                iterator1.reset();
-                iterator1.valid = true;
-                iterator2.valid = false;
-                return iterator1;
-            }
-            iterator2.reset();
-            iterator2.valid = true;
-            iterator1.valid = false;
-            return iterator2;
-        }
+    public ArrayIterator<Type> iterator() {
+        if (Collections.allocateIterators) return new ArrayIterator<Type>(this, false);
+        if (iterable == null) iterable = new ArrayIterable<Type>(this, false);
+        return iterable.iterator();
     }
 }

--- a/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/immutable/ImmutableObjectSet.java
+++ b/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/immutable/ImmutableObjectSet.java
@@ -75,7 +75,7 @@ public class ImmutableObjectSet<Type> extends ObjectSet<Type> {
 
     @Override
     @Deprecated
-    public void addAll(final Type... array) {
+    public boolean addAll(final Type... array) {
         throw new UnsupportedOperationException("Cannot modify ImmutableObjectSet.");
     }
 
@@ -87,7 +87,7 @@ public class ImmutableObjectSet<Type> extends ObjectSet<Type> {
 
     @Override
     @Deprecated
-    public void addAll(final Type[] array, final int offset, final int length) {
+    public boolean addAll(final Type[] array, final int offset, final int length) {
         throw new UnsupportedOperationException("Cannot modify ImmutableObjectSet.");
     }
 

--- a/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/lazy/LazyObjectMap.java
+++ b/kiwi/src/main/java/com/github/czyzby/kiwi/util/gdx/collection/lazy/LazyObjectMap.java
@@ -1,6 +1,7 @@
 package com.github.czyzby.kiwi.util.gdx.collection.lazy;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.ObjectSet;
 import com.github.czyzby.kiwi.util.gdx.asset.lazy.provider.ArrayObjectProvider;
@@ -148,7 +149,7 @@ public class LazyObjectMap<Key, Value> extends ObjectMap<Key, Value> {
     }
 
     @Override
-    public Value get(final Key key) {
+    public @Null <T extends Key> Value get(T key) {
         Value value = super.get(key);
         if (value == null) {
             value = provider.provide();
@@ -164,7 +165,7 @@ public class LazyObjectMap<Key, Value> extends ObjectMap<Key, Value> {
      * @param defaultValue returned if no value is set for the key. */
     @Override
     @Deprecated
-    public Value get(final Key key, final Value defaultValue) {
+    public Value get(Key key, @Null Value defaultValue) {
         return super.get(key, defaultValue);
     }
 

--- a/lml/src/main/java/com/github/czyzby/lml/parser/impl/tag/actor/ScrollPaneLmlTag.java
+++ b/lml/src/main/java/com/github/czyzby/lml/parser/impl/tag/actor/ScrollPaneLmlTag.java
@@ -29,10 +29,10 @@ public class ScrollPaneLmlTag extends AbstractActorLmlTag {
     /** @param child will be set as the managed child. */
     protected void setChild(final Actor child) {
         final ScrollPane scrollPane = getScrollPane();
-        if (scrollPane.getWidget() != null) {
+        if (scrollPane.getActor() != null) {
             getParser().throwErrorIfStrict("Scroll pane can have only one child. Received another child: " + child);
         }
-        scrollPane.setWidget(child);
+        scrollPane.setActor(child);
     }
 
     /** @return casted actor. */

--- a/lml/src/main/java/com/github/czyzby/lml/util/collection/KeyNormalizingObjectMap.java
+++ b/lml/src/main/java/com/github/czyzby/lml/util/collection/KeyNormalizingObjectMap.java
@@ -23,7 +23,7 @@ public abstract class KeyNormalizingObjectMap<Key, Value> extends ObjectMap<Key,
     }
 
     @Override
-    public Value get(Key key) {
+    public <T extends Key> Value get(T key) {
         if (key != null) {
             key = normalizeKey(key);
         }
@@ -72,8 +72,9 @@ public abstract class KeyNormalizingObjectMap<Key, Value> extends ObjectMap<Key,
         }
     }
 
-    /** @param key will be normalized, ensuring that all keys are equal according to the chosen standard.
+    /** @param <T> type of normalized key.
+     * @param key will be normalized, ensuring that all keys are equal according to the chosen standard.
      * @return normalized key.
      * @throws NullPointerException if key is null. */
-    protected abstract Key normalizeKey(final Key key);
+    protected abstract <T extends Key> T normalizeKey(final Key key);
 }


### PR DESCRIPTION
Same update as the previous one - #95.
Only required changes to comply with the most recent LibGDX API changes.
I've done some basic testing for LML and Kiwi, but it should be fine as there is not much change. The project version is lifted to _1.91.9.11_ and ready to roll. 

@czyzby I'd appreciate it if you could build and push these changes as a snapshot release, please.